### PR TITLE
Gameobjects as forward list branch pull to master

### DIFF
--- a/source/EngineTests.cpp
+++ b/source/EngineTests.cpp
@@ -32,9 +32,10 @@ void TenMil1(int args) {
 	std::chrono::steady_clock clock;
 	std::chrono::time_point const start = clock.now();
 
-	for (int i = 0; i < 10000000; i++) {
+	for (int i = 0; i < 1000; i++) {
 		GameObject& go = manager1.AddGO(GOManager::Cat::Players);
 		go.AddTransform();
+		go.Destroy();
 	}
 
 	std::chrono::time_point const end = clock.now();
@@ -43,6 +44,13 @@ void TenMil1(int args) {
 		<< std::endl;
 
 
-	manager1.AddGO(GOManager::Cat::Hazards);
+	manager1.AddGO(GOManager::Cat::Hazards).Destroy();
+
 	manager1.AddGO(GOManager::Cat::Players);
+
+	
+	std::cout << manager1.RunDestroyer() << std::endl;
+
+	return;
+
 }

--- a/source/EngineTests.cpp
+++ b/source/EngineTests.cpp
@@ -30,20 +30,18 @@ void TenMil1(int args) {
 	GOManager manager1, manager2;
 
 	std::chrono::steady_clock clock;
-	std::chrono::time_point start = clock.now();
+	std::chrono::time_point const start = clock.now();
 
 	for (int i = 0; i < 10000000; i++) {
 		GameObject& go = manager1.AddGO(GOManager::Cat::Players);
 		go.AddTransform();
 	}
 
-	std::chrono::time_point end = clock.now();
+	std::chrono::time_point const end = clock.now();
 	std::cout
 		<< std::chrono::duration_cast<std::chrono::microseconds>((end - start)).count()
 		<< std::endl;
 
-
-	auto something = manager1.clast(GOManager::Cat::Players);
 
 	manager1.AddGO(GOManager::Cat::Hazards);
 	manager1.AddGO(GOManager::Cat::Players);

--- a/source/GOManager.cpp
+++ b/source/GOManager.cpp
@@ -31,7 +31,7 @@ bool IsDestroyGlo(GameObject const& go) noexcept {
 	return go.IsDestroy();
 }
 
-size_t GOManager::Destroyer() {
+size_t GOManager::RunDestroyer() {
 	size_t remCnt = 0;
 	for (auto& e : pool)
 		remCnt += e.remove_if([](GameObject& g) noexcept -> bool { return g.IsDestroy(); } );

--- a/source/GOManager.cpp
+++ b/source/GOManager.cpp
@@ -15,11 +15,12 @@
 #include "GameObject.h"
 #include "GOManager.h"
 
+
+
 GOManager::GOManager() noexcept
 {
 	Trace("ctor GOM");
 	pool.resize(static_cast<int>(Cat::CategoryCount));
-	pool.at(static_cast<int>(Cat::Players)).reserve(500000);
 }
 
 GOManager::~GOManager() noexcept
@@ -27,28 +28,35 @@ GOManager::~GOManager() noexcept
 	Trace("dtor GOM");
 }
 
-GameObject& GOManager::AddGO(Cat c)
-{
-	return pool.at(static_cast<int>(c)).emplace_back();
+bool IsDestroyGlo(GameObject const& go) {
+	return go.IsDestroy();
 }
 
-std::vector<GameObject>::const_iterator GOManager::cbegin(Cat c)
+size_t GOManager::Destroyer() {
+	size_t remCnt = 0;
+	for (auto& e : pool)
+		remCnt += e.remove_if([](GameObject& g) noexcept -> bool { return g.IsDestroy(); } );
+	return remCnt;
+}
+
+GameObject& GOManager::AddGO(Cat c)
+{
+	return pool.at(static_cast<int>(c)).emplace_front();
+}
+
+std::forward_list<GameObject>::const_iterator GOManager::cbegin(Cat c)
 {
 	return pool.at(static_cast<int>(c)).cbegin();
 }
-std::vector<GameObject>::iterator GOManager::begin(Cat c)
+std::forward_list<GameObject>::iterator GOManager::begin(Cat c)
 {
 	return pool.at(static_cast<int>(c)).begin();
 }
-std::vector<GameObject>::const_iterator GOManager::clast(Cat c)
-{
-	return pool.at(static_cast<int>(c)).cend() - 1;
-}
-std::vector<GameObject>::const_iterator GOManager::cend(Cat c)
+std::forward_list<GameObject>::const_iterator GOManager::cend(Cat c)
 {
 	return pool.at(static_cast<int>(c)).cend();
 }
-std::vector<GameObject>::iterator GOManager::end(Cat c)
+std::forward_list<GameObject>::iterator GOManager::end(Cat c)
 {
 	return pool.at(static_cast<int>(c)).end();
 }

--- a/source/GOManager.cpp
+++ b/source/GOManager.cpp
@@ -20,7 +20,6 @@
 GOManager::GOManager() noexcept
 {
 	Trace("ctor GOM");
-	pool.resize(static_cast<int>(Cat::CategoryCount));
 }
 
 GOManager::~GOManager() noexcept
@@ -28,7 +27,7 @@ GOManager::~GOManager() noexcept
 	Trace("dtor GOM");
 }
 
-bool IsDestroyGlo(GameObject const& go) {
+bool IsDestroyGlo(GameObject const& go) noexcept {
 	return go.IsDestroy();
 }
 

--- a/source/GOManager.h
+++ b/source/GOManager.h
@@ -48,7 +48,7 @@ public:
 
 
 	// Should be called each frame end, before draw call.
-	size_t Destroyer();
+	size_t RunDestroyer();
 
 	//give access to the iterators
 	std::forward_list<GameObject>::const_iterator cbegin(Cat c);

--- a/source/GOManager.h
+++ b/source/GOManager.h
@@ -14,6 +14,7 @@
 ******************************************************************************/
 
 #include <vector>
+#include <forward_list>
 
 // forward reference
 typedef class Component Component;
@@ -45,16 +46,18 @@ public:
 
 	GameObject& AddGO(Cat c);
 
+	size_t Destroyer();
 
 	//give access to the iterators
-	std::vector<GameObject>::const_iterator cbegin(Cat c);
-	std::vector<GameObject>::iterator begin(Cat c);
-	std::vector<GameObject>::const_iterator cend(Cat c);
-	std::vector<GameObject>::iterator end(Cat c);
-	std::vector<GameObject>::const_iterator clast(Cat c);
+	std::forward_list<GameObject>::const_iterator cbegin(Cat c);
+	std::forward_list<GameObject>::iterator begin(Cat c);
+	std::forward_list<GameObject>::const_iterator cend(Cat c);
+	std::forward_list<GameObject>::iterator end(Cat c);
 
 private:
-	// avoiding c-style array, as vector has bounds checking.
-	std::vector<std::vector<GameObject>> pool;
+	// avoiding c-style array, as std::array has bounds checking.
+	// using forward list for GO holding, since its iterators do not get invalidated.
+
+	std::vector<std::forward_list<GameObject>> pool;
 
 };

--- a/source/GOManager.h
+++ b/source/GOManager.h
@@ -46,6 +46,8 @@ public:
 
 	GameObject& AddGO(Cat c);
 
+
+	// Should be called each frame end, before draw call.
 	size_t Destroyer();
 
 	//give access to the iterators

--- a/source/GOManager.h
+++ b/source/GOManager.h
@@ -13,7 +13,7 @@
 
 ******************************************************************************/
 
-#include <vector>
+#include <array>
 #include <forward_list>
 
 // forward reference
@@ -58,6 +58,6 @@ private:
 	// avoiding c-style array, as std::array has bounds checking.
 	// using forward list for GO holding, since its iterators do not get invalidated.
 
-	std::vector<std::forward_list<GameObject>> pool;
+	std::array<std::forward_list<GameObject>, static_cast<size_t>(Cat::CategoryCount)> pool;
 
 };

--- a/source/GameObject.cpp
+++ b/source/GameObject.cpp
@@ -26,6 +26,11 @@ bool GameObject::IsDestroy() const noexcept
 	return destroy;
 }
 
+void GameObject::Destroy() noexcept
+{
+	destroy = true;
+}
+
 GOUID GameObject::NewID() noexcept
 {
 	// critical state?

--- a/source/GameObject.cpp
+++ b/source/GameObject.cpp
@@ -60,6 +60,9 @@ GameObject::GameObject(GameObject&& go) noexcept
 
 GameObject& GameObject::operator=(GameObject&& go) noexcept
 {
+	if (this->id == go.id) {
+		return *this;
+	}
 	id = std::move(go.id);
 	destroy = std::move(go.destroy);
 	alive = std::move(go.alive);

--- a/source/GameObject.cpp
+++ b/source/GameObject.cpp
@@ -21,6 +21,11 @@
 
 GOUID GameObject::idTracker = 0;
 
+bool GameObject::IsDestroy() const noexcept
+{
+	return destroy;
+}
+
 GOUID GameObject::NewID() noexcept
 {
 	// critical state?
@@ -51,6 +56,19 @@ GameObject::GameObject(GameObject&& go) noexcept
 	transform = std::move(go.transform);
 	weapon = std::move(go.weapon);
 }
+
+GameObject& GameObject::operator=(GameObject&& go) noexcept
+{
+	id = std::move(go.id);
+	destroy = std::move(go.destroy);
+	alive = std::move(go.alive);
+	fData = std::move(go.fData);
+	transform = std::move(go.transform);
+	weapon = std::move(go.weapon);
+	return *this;
+}
+
+
 
 char const* GameObject::Exception::GetType() const noexcept
 {

--- a/source/GameObject.cpp
+++ b/source/GameObject.cpp
@@ -33,6 +33,7 @@ GOUID GameObject::NewID() noexcept
 	// end critical state?
 
 	return idTracker;
+	
 }
 
 GameObject::GameObject()  : 

--- a/source/GameObject.h
+++ b/source/GameObject.h
@@ -50,6 +50,7 @@ public:
 	Weapon& AddWeapon(Args... args);
 
 	bool IsDestroy() const noexcept;
+	void Destroy() noexcept;
 
 protected:
 	GOUID NewID() noexcept;

--- a/source/GameObject.h
+++ b/source/GameObject.h
@@ -38,16 +38,18 @@ public:
 	GameObject() ;
 	~GameObject() noexcept;
 	GameObject(GameObject&&) noexcept;
-
+	GameObject& operator=(GameObject&&) noexcept;
 
 	GameObject(const GameObject&) = delete;
 	GameObject& operator=(const GameObject&) = delete;
-	GameObject& operator=(GameObject&&) = delete;
+	
 
 	template <typename... Args>
 	Transform& AddTransform(Args... args);
 	template <typename... Args>
 	Weapon& AddWeapon(Args... args);
+
+	bool IsDestroy() const noexcept;
 
 protected:
 	GOUID NewID() noexcept;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -17,4 +17,5 @@
 
 int main(int args) {
 	TenMil1();
+	
 }


### PR DESCRIPTION
The backing structure for the game objects has been changed to use array and forward_list. Results are as follows:

- Efficiency improved by 60%. 
- Also added functionality for destroy in accordance with the forward_list.  
- Iterators are no longer invalid upon adding GameObject objects. 
- Iterators will stay valid until Destroyer() is called.